### PR TITLE
Simple setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     license='BSD',
     packages=find_packages(),
     zip_safe=False,
-    install_requires=['setuptools', 'decorator',],
+    install_requires=['decorator',],
     include_package_data=True,
     classifiers=[
         "Programming Language :: Python",


### PR DESCRIPTION
I threw together a quick setup.py to make installing with pip easy. It also pulls down and sets up the necessary decorator module. I'm not sure what license you are using but it looks like BSD so that's what I set in the setup file. I'm not all that familiar with creating a setup file so I went off another app I have installed to make it work. 

Example install.
pip install -e git+git://github.com/chrisjones-brack3t/django-ajax.git#egg=django-ajax

It successfully installs the two packages and I tested a quick end point I setup in a project I am building.
