### PR TITLE
Encoder was not passed for collections.Iterable objects on encode.

### DIFF
--- a/ajax/encoders.py
+++ b/ajax/encoders.py
@@ -140,7 +140,7 @@ class Encoders(object):
         if isinstance(record, collections.Iterable):
             ret = []
             for i in record:
-                ret.append(self.encode(i))
+                ret.append(self.encode(i, encoder))
         else:
             ret = encoder(record)
 


### PR DESCRIPTION
This was causing comments to not be escaped.
