### PR TITLE
Add per-call HTML escaping option.

### DIFF
--- a/ajax/encoders.py
+++ b/ajax/encoders.py
@@ -72,7 +72,6 @@ class DefaultEncoder(object):
         return self._escape(value)
 
     def _escape(self, value):
-        print '_escape %s' % (self.htmlescape)
         if self.htmlescape:
             return escape(value)
         return value


### PR DESCRIPTION
This does two things:

If you encode an iterable object it grabs the appropriate encoder for each element as opposed to donking off to the DefaultEncoder.

Also, it allows you to pass in an htmlescape argument to the encode method.  This makes it so you can register an ExcludeEncoder for a User object but only escape arguments when you need them to be, like in a template tag.
