### PR TITLE
catched Http404 exception type and return AjaxError response with 404 code

### DIFF
--- a/ajax/views.py
+++ b/ajax/views.py
@@ -1,4 +1,4 @@
-from django.http import HttpResponse
+from django.http import HttpResponse, Http404
 from django.utils import simplejson as json
 from django.utils.translation import ugettext as _
 from django.utils.importlib import import_module
@@ -34,6 +34,8 @@ def json_response(f, *args, **kwargs):
             raise result
     except AJAXError, e:
         result = e.get_response()
+    except Http404, e:
+        result = AJAXError(404, e.__str__()).get_response()
     except Exception, e:
         import sys
         type, message, trace = sys.exc_info()


### PR DESCRIPTION
It's very common use **get_object_or_404** or **get_list_or_404** shortcuts when you are implementing ajax endpoint, similar when you are implementing django view.

so, I don't see a reason to send to cliente http 500 error. 
