### PR TITLE
Speeding up JSON encoding

### DIFF
--- a/ajax/exceptions.py
+++ b/ajax/exceptions.py
@@ -35,5 +35,5 @@ class AJAXError(Exception):
         error.update(self.extra)
 
         response = self.RESPONSES[self.code]()
-        response.content = json.dumps(error, indent=4)
+        response.content = json.dumps(error, separators=(',', ':'))
         return response

--- a/ajax/views.py
+++ b/ajax/views.py
@@ -93,4 +93,4 @@ def endpoint_loader(request, application, model, **kwargs):
     if isinstance(data, HttpResponse):
         return data
     else:
-        return HttpResponse(json.dumps(data, indent=4, cls=DjangoJSONEncoder))
+        return HttpResponse(json.dumps(data, cls=DjangoJSONEncoder, separators=(',', ':')))


### PR DESCRIPTION
Using an indent in simplejson.dump slows encoding times by about 6x.

Also, as a minor adjustment, using a more compressed set of separators just to clean up extra unneeded whitespace in the response.
