### PR TITLE
If AJAX_PK_ATTR_NAME is set, we want to remove the original reference to "pk" since this is acting as a rename of the same variable

### DIFF
--- a/ajax/encoders.py
+++ b/ajax/encoders.py
@@ -43,7 +43,7 @@ class DefaultEncoder(object):
             ret = {}
 
         ret.update(data['fields'])
-        if AJAX_PK_ATTR_NAME and AJAX_PK_ATTR_NAME != 'pk':
+        if AJAX_PK_ATTR_NAME is not None and AJAX_PK_ATTR_NAME != 'pk' and 'pk' in data:
             ret[AJAX_PK_ATTR_NAME] = data['pk']
             del ret['pk']
 


### PR DESCRIPTION
The behavior of this acts as if it's renaming the original "pk" variable to something else. Without this, "pk" still persists as well as the new reference.

Not sure if the original behavior is intended or not, just an observation made. Feel free to reject. :)
