### PR TITLE
Fix issue with decoding exceptions.

### DIFF
--- a/ajax/exceptions.py
+++ b/ajax/exceptions.py
@@ -32,11 +32,15 @@ class AJAXError(Exception):
         self.extra = kwargs  # Any kwargs will be appended to the output.
 
     def get_response(self):
+        try:
+            msg = smart_str(self.msg.decode())
+        except (AttributeError,):
+            msg = smart_str(self.msg)
         error = {
             'success': False,
             'data': {
                 'code': self.code,
-                'message': smart_str(self.msg.decode())
+                'message': msg
             }
         }
         error.update(self.extra)


### PR DESCRIPTION
There's an error in that, given a `DatabaseError`, its not decodeable, which obscures the actual error.

Original traceback:

```
[2013-07-15 23:33:09,526] ERROR django.request - Internal Server Error: /ajax/wasatch/completed_tasks_graph.json
Traceback (most recent call last):
  File "/Users/justinlilly/.virtualenvs/snowbird/lib/python2.7/site-packages/django/core/handlers/base.py", line 111, in get_response
    response = callback(request, *callback_args, **callback_kwargs)
  File "<string>", line 2, in endpoint_loader
  File "/Users/justinlilly/.virtualenvs/snowbird/src/django-ajax/ajax/decorators.py", line 72, in json_response
    result = AJAXError(500, message, traceback=tb).get_response()
  File "/Users/justinlilly/.virtualenvs/snowbird/src/django-ajax/ajax/exceptions.py", line 43, in get_response
    'message': smart_str(self.msg.decode())
AttributeError: 'DatabaseError' object has no attribute 'decode'
```
