### PR TITLE
Try to use Python's built-in json module.

### DIFF
--- a/ajax/exceptions.py
+++ b/ajax/exceptions.py
@@ -1,4 +1,8 @@
-from django.utils import simplejson as json
+try:
+    import json
+except ImportError:
+    from django.utils import simplejson as json
+
 from django.utils.encoding import smart_str
 from django.http import HttpResponse, HttpResponseNotFound, \
     HttpResponseForbidden, HttpResponseNotAllowed, HttpResponseServerError, \

--- a/ajax/middleware/DebugToolbar.py
+++ b/ajax/middleware/DebugToolbar.py
@@ -1,5 +1,9 @@
+try:
+    import json
+except ImportError:
+    from django.utils import simplejson as json
+
 from debug_toolbar.middleware import DebugToolbarMiddleware, add_content_handler
-from django.utils import simplejson as json
 from django.core.serializers.json import DjangoJSONEncoder
 
 

--- a/ajax/views.py
+++ b/ajax/views.py
@@ -1,6 +1,10 @@
+try:
+    import json
+except ImportError:
+    from django.utils import simplejson as json
+
 from django.conf import settings
 from django.http import HttpResponse
-from django.utils import simplejson as json
 from django.utils.translation import ugettext as _
 from django.utils.importlib import import_module
 from django.utils.log import getLogger


### PR DESCRIPTION
According to the Django 1.5 [release notes](https://docs.djangoproject.com/en/dev/releases/1.5/#system-version-of-simplejson-no-longer-used),

> Django 1.5 deprecates django.utils.simplejson in favor of Python 2.6’s built-in json module.

In Django 1.7a2, importing `django.utils.simplejson` raises the exception:

```
ImportError: cannot import name simplejson
```

These modifications attempt to import Python's built-in json module, and if that fails, to attempt to use `django.utils.simplejson`.
