### PR TITLE
Deny list access unless it's specifically allowed.

### DIFF
--- a/ajax/endpoints.py
+++ b/ajax/endpoints.py
@@ -88,6 +88,9 @@ class ModelEndpoint(object):
         items_per_page = min(max_items_per_page, requested_items_per_page)
         current_page = request.POST.get("current_page", 1)
 
+        if not self.can_list(request.user):
+            raise AJAXError(403, _("Access to this endpoint is forbidden"))
+
         if hasattr(self, 'get_queryset'):
             objects = self.get_queryset(request.user)
         else:
@@ -235,6 +238,7 @@ class ModelEndpoint(object):
     can_create = _user_is_active_or_staff
     can_update = _user_is_active_or_staff
     can_delete = _user_is_active_or_staff
+    can_list = lambda *args, **kwargs: False
 
     def authenticate(self, request, application, method):
         """Authenticate the AJAX request.

--- a/tests/example/endpoints.py
+++ b/tests/example/endpoints.py
@@ -1,7 +1,7 @@
 from ajax import endpoint
 from ajax.decorators import login_required
 from ajax.endpoints import ModelEndpoint
-from .models import Widget
+from .models import Widget, Category
 
 
 @login_required
@@ -13,5 +13,10 @@ def echo(request):
 class WidgetEndpoint(ModelEndpoint):
     model = Widget
     max_per_page = 100
+    can_list = lambda *args, **kwargs: True
+
+class CategoryEndpoint(ModelEndpoint):
+    model = Category
 
 endpoint.register(Widget, WidgetEndpoint)
+endpoint.register(Category, CategoryEndpoint)

--- a/tests/example/tests.py
+++ b/tests/example/tests.py
@@ -1,8 +1,9 @@
 from django.test import TestCase
 from django.contrib.auth.models import User
 import json
-from .models import Widget
-from .endpoints import WidgetEndpoint
+from ajax.exceptions import AJAXError
+from .models import Widget, Category
+from .endpoints import WidgetEndpoint, CategoryEndpoint
 
 
 class BaseTest(TestCase):
@@ -87,11 +88,13 @@ class EndpointTests(BaseTest):
 class MockRequest(object):
     def __init__(self, **kwargs):
         self.POST = kwargs
+        self.user = None
 
 
 class ModelEndpointTests(BaseTest):
     def setUp(self):
         self.list_endpoint = WidgetEndpoint('example', Widget, 'list')
+        self.category_endpoint = CategoryEndpoint('example', Category, 'list')
 
     def test_list_returns_all_items(self):
         results = self.list_endpoint.list(MockRequest())
@@ -101,6 +104,9 @@ class ModelEndpointTests(BaseTest):
         self.list_endpoint.max_per_page = 1
         results = self.list_endpoint.list(MockRequest())
         self.assertEqual(len(results), 1)
+
+    def test_list__ajaxerror_if_can_list_isnt_set(self):
+        self.assertRaises(AJAXError, self.category_endpoint.list, MockRequest())
 
     def test_out_of_range_returns_empty_list(self):
         results = self.list_endpoint.list(MockRequest(current_page=99))


### PR DESCRIPTION
We weren't properly checking permissions around listing of models.

We will need to bump version (if following semver) because it's technically backwards incompatible.

Before we do that, today I'm going to be changing the API (again) to list view, so might as well do them both at once.
