### PR TITLE
Django 1.9 support: Remove dependency on django.conf.urls.patterns

### DIFF
--- a/ajax/urls.py
+++ b/ajax/urls.py
@@ -1,14 +1,25 @@
 from __future__ import absolute_import
 from django.conf.urls import *
 from django.views.static import serve
+from ajax import views
+import django
 import os
 
 JAVASCRIPT_PATH = "%s/js" % os.path.dirname(__file__)
 
-urlpatterns = patterns('ajax.views',
-    (r'^(?P<application>\w+)/(?P<model>\w+).json', 'endpoint_loader'),
-    (r'^(?P<application>\w+)/(?P<model>\w+)/(?P<method>\w+).json', 'endpoint_loader'),
-    (r'^(?P<application>\w+)/(?P<model>\w+)/(?P<pk>\d+)/(?P<method>\w+)/?(?P<taggit_command>(add|remove|set|clear|similar))?.json$', 'endpoint_loader'),
-    (r'^js/(?P<path>.*)$', serve,
-        {'document_root': JAVASCRIPT_PATH}),
-)
+if django.VERSION < (1, 8):
+    urlpatterns = patterns('ajax.views',
+        (r'^(?P<application>\w+)/(?P<model>\w+).json', 'endpoint_loader'),
+        (r'^(?P<application>\w+)/(?P<model>\w+)/(?P<method>\w+).json', 'endpoint_loader'),
+        (r'^(?P<application>\w+)/(?P<model>\w+)/(?P<pk>\d+)/(?P<method>\w+)/?(?P<taggit_command>(add|remove|set|clear|similar))?.json$', 'endpoint_loader'),
+        (r'^js/(?P<path>.*)$', serve,
+            {'document_root': JAVASCRIPT_PATH}),
+    )
+else:
+    urlpatterns = [
+        url(r'^(?P<application>\w+)/(?P<model>\w+).json', views.endpoint_loader),
+        url(r'^(?P<application>\w+)/(?P<model>\w+)/(?P<method>\w+).json', views.endpoint_loader),
+        url(r'^(?P<application>\w+)/(?P<model>\w+)/(?P<pk>\d+)/(?P<method>\w+)/?(?P<taggit_command>(add|remove|set|clear|similar))?.json$', views.endpoint_loader),
+        url(r'^js/(?P<path>.*)$', serve,
+            {'document_root': JAVASCRIPT_PATH}),
+    ]

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,7 +1,15 @@
 from __future__ import absolute_import
-from django.conf.urls import patterns, include, url
+import django
+try:
+    from django.conf.urls import patterns, include, url
+except ImportError:
+    from django.conf.urls import include, url
 
-
-urlpatterns = patterns('',
-    url(r'^ajax/', include('ajax.urls')),
-)
+if django.VERSION < (1, 8):
+    urlpatterns = patterns('',
+        url(r'^ajax/', include('ajax.urls')),
+    )
+else:
+    urlpatterns = [
+        url(r'^ajax/', include('ajax.urls'))
+    ]


### PR DESCRIPTION
This PR switches urlspatterns to use a list on Django versions that allow it (1.8+). This allows the tests to pass on my computer for Django 1.9.6, 1.8.13, and 1.7.11 for Python 2.7 and 3.5.