### PR TITLE
Django 1.10: Replace test fixture reliance on deprecated SHA1 hasher

### DIFF
--- a/ajax/urls.py
+++ b/ajax/urls.py
@@ -1,14 +1,25 @@
 from __future__ import absolute_import
 from django.conf.urls import *
 from django.views.static import serve
+from ajax import views
+import django
 import os
 
 JAVASCRIPT_PATH = "%s/js" % os.path.dirname(__file__)
 
-urlpatterns = patterns('ajax.views',
-    (r'^(?P<application>\w+)/(?P<model>\w+).json', 'endpoint_loader'),
-    (r'^(?P<application>\w+)/(?P<model>\w+)/(?P<method>\w+).json', 'endpoint_loader'),
-    (r'^(?P<application>\w+)/(?P<model>\w+)/(?P<pk>\d+)/(?P<method>\w+)/?(?P<taggit_command>(add|remove|set|clear|similar))?.json$', 'endpoint_loader'),
-    (r'^js/(?P<path>.*)$', serve,
-        {'document_root': JAVASCRIPT_PATH}),
-)
+if django.VERSION < (1, 8):
+    urlpatterns = patterns('ajax.views',
+        (r'^(?P<application>\w+)/(?P<model>\w+).json', 'endpoint_loader'),
+        (r'^(?P<application>\w+)/(?P<model>\w+)/(?P<method>\w+).json', 'endpoint_loader'),
+        (r'^(?P<application>\w+)/(?P<model>\w+)/(?P<pk>\d+)/(?P<method>\w+)/?(?P<taggit_command>(add|remove|set|clear|similar))?.json$', 'endpoint_loader'),
+        (r'^js/(?P<path>.*)$', serve,
+            {'document_root': JAVASCRIPT_PATH}),
+    )
+else:
+    urlpatterns = [
+        url(r'^(?P<application>\w+)/(?P<model>\w+).json', views.endpoint_loader),
+        url(r'^(?P<application>\w+)/(?P<model>\w+)/(?P<method>\w+).json', views.endpoint_loader),
+        url(r'^(?P<application>\w+)/(?P<model>\w+)/(?P<pk>\d+)/(?P<method>\w+)/?(?P<taggit_command>(add|remove|set|clear|similar))?.json$', views.endpoint_loader),
+        url(r'^js/(?P<path>.*)$', serve,
+            {'document_root': JAVASCRIPT_PATH}),
+    ]

--- a/tests/example/fixtures/users.json
+++ b/tests/example/fixtures/users.json
@@ -12,7 +12,7 @@
             "last_login": "2011-05-07 15:19:28+00:00",
             "groups": [],
             "user_permissions": [],
-            "password": "pbkdf2_sha256$30000$xjv2a2hPmwMw$B+9JfadSwb98uFmr/+GLdKrQ8IeZ1SzRkB7HwHehsag=",
+            "password": "sha1$5c0a1$458aedb8565e65f687b8332c4183eb9556459980",
             "email": "joe@joestump.net",
             "date_joined": "2011-05-07 15:19:28+00:00"
         }

--- a/tests/example/fixtures/users.json
+++ b/tests/example/fixtures/users.json
@@ -12,7 +12,7 @@
             "last_login": "2011-05-07 15:19:28+00:00",
             "groups": [],
             "user_permissions": [],
-            "password": "sha1$5c0a1$458aedb8565e65f687b8332c4183eb9556459980",
+            "password": "pbkdf2_sha256$30000$xjv2a2hPmwMw$B+9JfadSwb98uFmr/+GLdKrQ8IeZ1SzRkB7HwHehsag=",
             "email": "joe@joestump.net",
             "date_joined": "2011-05-07 15:19:28+00:00"
         }

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -170,3 +170,7 @@ JENKINS_TEST_RUNNER = 'django_jenkins.runner.CITestSuiteRunner'
 
 # django-ajax specific settings
 MAX_PER_PAGE = 20
+# Explicitly allow the deprecated SHA1 hasher to speed up tests
+PASSWORD_HASHERS = [
+    'django.contrib.auth.hashers.SHA1PasswordHasher',
+]

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,7 +1,15 @@
 from __future__ import absolute_import
-from django.conf.urls import patterns, include, url
+import django
+try:
+    from django.conf.urls import patterns, include, url
+except ImportError:
+    from django.conf.urls import include, url
 
-
-urlpatterns = patterns('',
-    url(r'^ajax/', include('ajax.urls')),
-)
+if django.VERSION < (1, 8):
+    urlpatterns = patterns('',
+        url(r'^ajax/', include('ajax.urls')),
+    )
+else:
+    urlpatterns = [
+        url(r'^ajax/', include('ajax.urls'))
+    ]


### PR DESCRIPTION
Django 1.10 has removed support for the SHA1 hasher in the default list of hashers. This PR replaces the password in the users.json test fixture with a newly hashed password.

Pull request #70 should be merged before this pull request.
